### PR TITLE
fix(advantagekit): move .wpilog files to advantagekit/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ bin/
 # Simulation GUI and other tools window save files
 *-window.json
 simgui*.json
+networktables.json
 
 # Version file
 src/main/java/frc/robot/BuildConstants.java

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 # Log file
 *.log
 *.wpilog
+advantagekit/logs/
 
 # BlueJ files
 *.ctxt

--- a/src/main/java/frc/lib/advantagekit/LoggerUtil.java
+++ b/src/main/java/frc/lib/advantagekit/LoggerUtil.java
@@ -1,5 +1,8 @@
 package frc.lib.advantagekit;
 
+import java.io.File;
+import java.nio.file.Path;
+
 import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
@@ -8,37 +11,50 @@ import frc.robot.BuildConstants;
 import frc.robot.Robot;
 
 public class LoggerUtil {
-    public static void initializeLogger() {
-        Logger logger = Logger.getInstance();
+  public static final String kLogDirectory = "advantagekit/logs";
 
-        // Record metadata
-        logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
-        logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
-        logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
-        logger.recordMetadata("GitDate", BuildConstants.GIT_DATE);
-        logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
-        switch (BuildConstants.DIRTY) {
-            case 0:
-                logger.recordMetadata("GitDirty", "All changes committed");
-                break;
-            case 1:
-                logger.recordMetadata("GitDirty", "Uncomitted changes");
-                break;
-            default:
-                logger.recordMetadata("GitDirty", "Unknown");
-                break;
-        }
+  public static void initializeLogger() {
+    Logger logger = Logger.getInstance();
 
-        // Set up data receivers & replay source
-        if (Robot.isSimulation()) {
-            logger.addDataReceiver(new WPILOGWriter(""));
-            logger.addDataReceiver(new NT4Publisher());
-        } else {
-            logger.addDataReceiver(new WPILOGWriter("/media/sda1/"));
-            logger.addDataReceiver(new NT4Publisher());
-        }
+    // Record metadata
+    logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
+    logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
+    logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+    logger.recordMetadata("GitDate", BuildConstants.GIT_DATE);
+    logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+    logger.recordMetadata("GitDirty", getGitDirtyString());
 
-        // Start AdvantageKit logger
-        logger.start();
+    // Set up data receivers & replay source
+    if (Robot.isSimulation()) {
+      logger.addDataReceiver(new WPILOGWriter(getLogPath()));
+      logger.addDataReceiver(new NT4Publisher());
+    } else {
+      logger.addDataReceiver(new WPILOGWriter("/media/sda1/"));
+      logger.addDataReceiver(new NT4Publisher());
     }
+
+    // Start AdvantageKit logger
+    logger.start();
+  }
+
+  private static String getGitDirtyString() {
+    switch (BuildConstants.DIRTY) {
+      case 0:
+        return "All changes committed";
+      case 1:
+        return "Uncomitted changes";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private static String getLogPath() {
+    File file = Path.of(kLogDirectory).toFile();
+
+    if (!file.exists()) {
+      file.mkdirs();
+    }
+
+    return file.getAbsolutePath();
+  }
 }


### PR DESCRIPTION
By default in simulation, advantagekit logs are dumped to the project parent directory. This PR moves them to the `advantagekit/logs/` directory to reduce clutter.